### PR TITLE
Add missing CTYPES imports

### DIFF
--- a/recipe/ctypes.patch
+++ b/recipe/ctypes.patch
@@ -6,7 +6,7 @@
  # The udunits2 library needs to be in a standard path o/w export LD_LIBRARY_PATH
 -from ctypes import *
 -udunits=CDLL("libudunits2.so")
-+from ctypes import CDLL
++from ctypes import CDLL, CFUNCTYPE, c_int, c_char_p
 +import os.path
 +import sys
 +

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
     skip: True  # [win or py3k]
-    number: 0
+    number: 1
     script: python setup.py install --single-version-externally-managed --record record.txt
     entry_points:
         - cfchecks = cfchecker:cfchecks_main
@@ -36,6 +36,7 @@ requirements:
 test:
     commands:
         - cfchecks -h
+        - cfchecks http://dapds00.nci.org.au/thredds/dodsC/ua8/ARCCSS_Data-7/v1-0/HeatIndexVars_dailymax_WRFMK3_5_FutureOEHLu_2040-2049.nc
     imports:
         - cfchecker
 


### PR DESCRIPTION
The ctypes.patch file breaks the check function by removing several
imports, add them back in. Also add a test to check CF compiance of a
file (over OPeNDAP to avoid downloading data)